### PR TITLE
Fix: 修复工作流在非PR事件下的报错

### DIFF
--- a/.github/workflows/regression-test.yml
+++ b/.github/workflows/regression-test.yml
@@ -41,8 +41,8 @@ jobs:
         echo "Generating regression test report..."
         # 生成测试报告
     
-    - name: Comment PR (if failed)
-      if: failure()
+    - name: Comment PR (if failed and is PR)
+      if: failure() && github.event_name == 'pull_request'
       uses: actions/github-script@v6
       with:
         script: |
@@ -53,8 +53,8 @@ jobs:
             body: '❌ 回归测试失败，请修复后再合并\n\n请检查：\n1. 单元测试是否通过\n2. 是否破坏了现有功能\n3. 测试报告详情'
           })
     
-    - name: Comment PR (if success)
-      if: success()
+    - name: Comment PR (if success and is PR)
+      if: success() && github.event_name == 'pull_request'
       uses: actions/github-script@v6
       with:
         script: |


### PR DESCRIPTION
## 修复内容

修复了 regression-test 工作流在手动触发时（workflow_dispatch）尝试评论PR导致的404错误。

## 改动
- 添加条件判断：只在 PR 事件时才尝试评论
- `if: failure() && github.event_name == 'pull_request'`
- `if: success() && github.event_name == 'pull_request'`

## 测试
- 手动触发工作流不会再报错
- PR触发时仍会正常评论